### PR TITLE
Fix typos

### DIFF
--- a/Embed-Testing.html
+++ b/Embed-Testing.html
@@ -26,7 +26,7 @@
 
     <main>
         <h2>This page is for testing embeds</h2>
-        <p>Feel free to examine the HTML content to see how to do it yoiurself, or just have a look around!</p>
+        <p>Feel free to examine the HTML content to see how to do it yourself, or just have a look around!</p>
         <iframe allow="autoplay *; encrypted-media *;" frameborder="0" height="450" style="width:100%;max-width:660px;overflow:hidden;background:transparent;" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation" src="https://embed.music.apple.com/us/station/99-1-joy-fm/ra.1461000223"></iframe>
     </main>
 


### PR DESCRIPTION
## Summary
- correct spelling on embed testing page

## Testing
- `codespell -S docs/kitten.svg`

------
https://chatgpt.com/codex/tasks/task_e_683ff80680fc83278bf7b60b85561d2b